### PR TITLE
push container to gcp

### DIFF
--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -36,10 +36,6 @@ jobs:
           workload_identity_provider: projects/675933940278/locations/global/workloadIdentityPools/github-actions/providers/github
           service_account: github-actions@template-455111.iam.gserviceaccount.com
 
-      - run: |
-          echo "Access Token: ${{ steps.auth.outputs.access_token }}"
-          echo "${{ steps.auth.outputs }}"
-
       - name: Registry Auth
         id: docker-auth
         uses: docker/login-action@v3
@@ -48,11 +44,18 @@ jobs:
           password: '${{ steps.auth.outputs.access_token }}'
           registry: europe-west2-docker.pkg.dev
 
-      - name: Build & push image
+      - name: Build & Push
+        uses: docker/build-push-action@v5
         env:
           GAR_URL: europe-west2-docker.pkg.dev/template-455111/gcr-template
-        run: |
-          IMAGE_TAG=${{ env.GAR_URL }}:${{ github.sha }}
-
-          docker build -t $IMAGE_TAG .
-          docker push $IMAGE_TAG
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          target: final
+          build-args: |
+            SHA=${{ inputs.github_ref }}
+            VERSION=${{ inputs.app_version }}
+          push: true
+          tags: ${{ env.GAR_URL }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Docker Auth
         id: docker-auth
-        uses: 'docker/login-action@v1'
+        uses: 'docker/login-action@v3'
         with:
           username: 'oauth2accesstoken'
           password: '${{ steps.auth.outputs.access_token }}'

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -1,0 +1,52 @@
+name: Build & Deploy
+
+on:
+  push:
+    branches:
+      - main
+      - ci-test/**
+    # paths:
+    #   - 'apps/api/**'
+    #   - 'packages/**'
+
+  workflow_dispatch:
+    inputs:
+      app_version:
+        description: 'App version'
+        required: true
+
+jobs:
+  build-push:
+    permissions:
+      contents: read
+      id-token: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Google Auth
+        id: auth
+        uses: 'google-github-actions/auth@v2'
+        with:
+          project_id: 'template'
+          workload_identity_provider: 'projects/675933940278/locations/global/workloadIdentityPools/wip-github-actions/providers/github'
+
+      - name: Docker Auth
+        id: docker-auth
+        uses: 'docker/login-action@v1'
+        with:
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
+          registry: 'europe-west2-docker.pkg.dev'
+
+      - name: Build & push image
+        env:
+          GAR_URL: 'europe-west2-docker.pkg.dev/template-455111/gcr-template'
+        run: |
+          IMAGE_TAG=${{ env.GAR_URL }}:${{ github.sha }}
+
+          docker build -t $IMAGE_TAG .
+          docker push $IMAGE_TAG

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -35,6 +35,9 @@ jobs:
           workload_identity_provider: projects/675933940278/locations/global/workloadIdentityPools/github-actions/providers/github
           service_account: github-actions@template-455111.iam.gserviceaccount.com
 
+      - run: |
+          cat '${{ steps.auth.outputs }}'
+
       - name: Registry Auth
         id: docker-auth
         uses: docker/login-action@v3

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       app_version:
-        description: 'App version'
+        description: App version
         required: true
 
 jobs:
@@ -29,22 +29,23 @@ jobs:
 
       - name: Google Auth
         id: auth
-        uses: 'google-github-actions/auth@v2'
+        uses: google-github-actions/auth@v2
         with:
-          project_id: 'template'
-          workload_identity_provider: 'projects/675933940278/locations/global/workloadIdentityPools/github-actions/providers/github'
+          token_format: access_token
+          project_id: template
+          workload_identity_provider: projects/675933940278/locations/global/workloadIdentityPools/github-actions/providers/github
 
       - name: Docker Auth
         id: docker-auth
-        uses: 'docker/login-action@v3'
+        uses: docker/login-action@v3
         with:
-          username: 'oauth2accesstoken'
-          password: '${{ steps.auth.outputs.access_token }}'
-          registry: 'europe-west2-docker.pkg.dev'
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+          registry: europe-west2-docker.pkg.dev
 
       - name: Build & push image
         env:
-          GAR_URL: 'europe-west2-docker.pkg.dev/template-455111/gcr-template'
+          GAR_URL: europe-west2-docker.pkg.dev/template-455111/gcr-template
         run: |
           IMAGE_TAG=${{ env.GAR_URL }}:${{ github.sha }}
 

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -15,6 +15,9 @@ on:
         description: App version
         required: true
 
+env:
+  CONTAINER_REGISTRY_NAME: europe-west2-docker.pkg.dev
+
 jobs:
   build-push:
     permissions:
@@ -22,6 +25,7 @@ jobs:
       id-token: write
 
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,8 +39,8 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           token_format: 'access_token'
-          workload_identity_provider: projects/675933940278/locations/global/workloadIdentityPools/github-actions/providers/github
-          service_account: github-actions@template-455111.iam.gserviceaccount.com
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           access_token_lifetime: 300s
 
       - name: Registry Auth
@@ -45,7 +49,7 @@ jobs:
         with:
           username: oauth2accesstoken
           password: '${{ steps.auth.outputs.access_token }}'
-          registry: europe-west2-docker.pkg.dev
+          registry: ${{ env.CONTAINER_REGISTRY_NAME }}
 
       - name: Build & Push
         uses: docker/build-push-action@v6
@@ -57,4 +61,4 @@ jobs:
             SHA=${{ inputs.github_ref }}
             VERSION=${{ inputs.app_version }}
           push: true
-          tags: europe-west2-docker.pkg.dev/template-455111/gcr-template/api:${{ github.sha }}
+          tags: ${{ env.CONTAINER_REGISTRY_NAME }}/template-455111/gcr-template/api:${{ github.sha }}

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: 'google-github-actions/auth@v2'
         with:
           project_id: 'template'
-          workload_identity_provider: 'projects/675933940278/locations/global/workloadIdentityPools/wip-github-actions/providers/github'
+          workload_identity_provider: 'projects/675933940278/locations/global/workloadIdentityPools/github-actions/providers/github'
 
       - name: Docker Auth
         id: docker-auth

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+          password: '${{ steps.auth.outputs.access_token }}'
           registry: europe-west2-docker.pkg.dev
 
       - name: Build & push image

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -31,11 +31,11 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          token_format: access_token
           project_id: template
           workload_identity_provider: projects/675933940278/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: github-actions@template-455111.iam.gserviceaccount.com
 
-      - name: Docker Auth
+      - name: Registry Auth
         id: docker-auth
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -35,9 +35,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           token_format: 'access_token'
-          project_id: template
           workload_identity_provider: projects/675933940278/locations/global/workloadIdentityPools/github-actions/providers/github
           service_account: github-actions@template-455111.iam.gserviceaccount.com
+          access_token_lifetime: 300s
 
       - name: Registry Auth
         id: docker-auth
@@ -57,4 +57,4 @@ jobs:
             SHA=${{ inputs.github_ref }}
             VERSION=${{ inputs.app_version }}
           push: true
-          tags: europe-west2-docker.pkg.dev/template-455111/gcr-template:${{ github.sha }}
+          tags: europe-west2-docker.pkg.dev/template-455111/gcr-template/api:${{ github.sha }}

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -36,7 +36,8 @@ jobs:
           service_account: github-actions@template-455111.iam.gserviceaccount.com
 
       - run: |
-          cat '${{ steps.auth.outputs }}'
+          echo "Access Token: ${{ steps.auth.outputs.access_token }}"
+          echo "${{ steps.auth.outputs }}"
 
       - name: Registry Auth
         id: docker-auth

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -31,6 +31,7 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
+          token_format: 'access_token'
           project_id: template
           workload_identity_provider: projects/675933940278/locations/global/workloadIdentityPools/github-actions/providers/github
           service_account: github-actions@template-455111.iam.gserviceaccount.com

--- a/.github/workflows/build-deploy-api.yaml
+++ b/.github/workflows/build-deploy-api.yaml
@@ -27,6 +27,9 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Google Auth
         id: auth
         uses: google-github-actions/auth@v2
@@ -45,9 +48,7 @@ jobs:
           registry: europe-west2-docker.pkg.dev
 
       - name: Build & Push
-        uses: docker/build-push-action@v5
-        env:
-          GAR_URL: europe-west2-docker.pkg.dev/template-455111/gcr-template
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/api/Dockerfile
@@ -56,6 +57,4 @@ jobs:
             SHA=${{ inputs.github_ref }}
             VERSION=${{ inputs.app_version }}
           push: true
-          tags: ${{ env.GAR_URL }}:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: europe-west2-docker.pkg.dev/template-455111/gcr-template:${{ github.sha }}


### PR DESCRIPTION
New github actions workflow that builds container and pushes to Google Artifact Registry.

Added 2 new GitHub secrets - service account (access) + workload identity provider (auth)